### PR TITLE
RVM compatibility fix

### DIFF
--- a/lib/hazel/cli.rb
+++ b/lib/hazel/cli.rb
@@ -101,7 +101,6 @@ module Hazel
     def create_rvm_gemset
       if @rvm_gemset
         rvm_path = File.expand_path(ENV['rvm_path'] || '~/.rvm')
-        $LOAD_PATH.unshift File.join(rvm_path, 'lib')
         require 'rvm'
 
         rvm_ruby = "#{ENV['RUBY_VERSION']}@#{@app_path}"


### PR DESCRIPTION
Running Hazel with the --rvm-gemset flag on a system with the rvm gem installed causes a RuntimeError.

```
RVM - Ruby integration was extracted to a separate gem, it should be installed by default with RVM, remove the `$LOAD_PATH.unshift` line and all should be fine again. (RuntimeError)
```
