### PR TITLE
Require Sinatra in the Application

### DIFF
--- a/lib/templates/app.rb
+++ b/lib/templates/app.rb
@@ -1,3 +1,5 @@
+require 'sinatra'
+
 class <%= @name.camel_case %> < Sinatra::Base
 
   set :public_folder => "public", :static => true


### PR DESCRIPTION
This fixes issues where the 'Sinatra' constant is not visible to Ruby
and causes applications to fail during startup when started using
`ruby my_app.rb` as opposed to `rackup`.