### PR TITLE
Update README to include instructions to run app

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ App using Redis, RVM, and Git repo
 
     hazel my_app --redis --rvm --git-repo
 
+After Hazel is done generating an app, you can `cd` into your apps
+directory and `rackup`
+
+    cd my_app; rackup
+
 ## Architecture
 
 The template autoloads files in config/initializers and


### PR DESCRIPTION
It's a little unclear that to get the app running correctly
one must run `rackup` instead of the usual Sinatra way of
running `ruby my_app.rb` so I'm hoping this will help :)